### PR TITLE
Using Either for all Klient returns (even when success means returning Unit)

### DIFF
--- a/src/main/java/org/zalando/nakadi/client/Client.java
+++ b/src/main/java/org/zalando/nakadi/client/Client.java
@@ -37,9 +37,9 @@ public interface Client {
      * hash over Event.orderingKey).
      * @param topic  target topic
      * @param event  event to be posted
-     * @return Option representing the error message or None in case of success
+     * @return Void in case of success
      */
-    Future<Option<String>> postEvent(final String topic, final Event event);
+    Future<Either<String,Void>> postEvent(final String topic, final Event event);
 
     /**
      * Get specific partition
@@ -57,9 +57,9 @@ public interface Client {
      * @param topic  topic where the partition is located
      * @param partitionId  id of the target partition
      * @param event event to be posted
-     * @return Option representing the error message or None in case of success
+     * @return Void in case of success
      */
-    Future<Option<String>> postEventToPartition(String topic, String partitionId, Event event);
+    Future<Either<String,Void>> postEventToPartition(String topic, String partitionId, Event event);
 
     /**
      * Blocking subscription to events of specified topic and partition.

--- a/src/main/java/org/zalando/nakadi/client/JavaClientImpl.java
+++ b/src/main/java/org/zalando/nakadi/client/JavaClientImpl.java
@@ -34,8 +34,8 @@ class JavaClientImpl implements Client {
     }
 
     @Override
-    public Future<Option<String>> postEvent(final String topic, final Event event) {
-        return Utils.convert(klient.postEvent(topic, event));
+    public Future<Either<String,Void>> postEvent(final String topic, final Event event) {
+        return Utils.convert((scala.concurrent.Future) klient.postEvent(topic, event));
     }
 
     @Override
@@ -44,8 +44,8 @@ class JavaClientImpl implements Client {
     }
 
     @Override
-    public Future<Option<String>> postEventToPartition(final String topic, final String partitionId, final Event event) {
-        return Utils.convert(klient.postEventToPartition(topic, partitionId, event));
+    public Future<Either<String,Void>> postEventToPartition(final String topic, final String partitionId, final Event event) {
+        return Utils.convert((scala.concurrent.Future) klient.postEventToPartition(topic, partitionId, event));
     }
 
     @Override

--- a/src/main/scala/org/zalando/nakadi/client/Klient.scala
+++ b/src/main/scala/org/zalando/nakadi/client/Klient.scala
@@ -53,7 +53,7 @@ trait Klient {
    * @param event  event to be posted
    * @return Option representing the error message or None in case of success
    */
-  def postEvent(topic: String, event: Event): Future[Option[String]]
+  def postEvent(topic: String, event: Event): Future[Either[String,Unit]]
 
   /**
    * Get specific partition
@@ -73,7 +73,7 @@ trait Klient {
    * @param event event to be posted
    * @return Option representing the error message or None in case of success
    */
-  def postEventToPartition(topic: String, partitionId: String, event: Event): Future[Option[String]]
+  def postEventToPartition(topic: String, partitionId: String, event: Event): Future[Either[String,Unit]]
 
   /**
    * Blocking subscription to events of specified topic and partition.

--- a/src/main/scala/org/zalando/nakadi/client/KlientImpl.scala
+++ b/src/main/scala/org/zalando/nakadi/client/KlientImpl.scala
@@ -183,13 +183,13 @@ protected class KlientImpl(val endpoint: URI,
    * @param event  event to be posted
    * @return Option representing the error message or None in case of success
    */
-  override def postEvent(topic: String, event: Event): Future[Option[String]] = {
+  override def postEvent(topic: String, event: Event): Future[Either[String,Unit]] = {
      checkNotNull(topic, "topic must not be null")
      performEventPost(String.format(URI_EVENT_POST, topic), event)
   }
 
 
-  private def performEventPost(uriPart: String, event: Event): Future[Option[String]] = {
+  private def performEventPost(uriPart: String, event: Event): Future[Either[String,Unit]] = {
     checkNotNull(event, "event must not be null")
 
     val request = HttpRequest(uri = uriPart, method = POST)
@@ -203,7 +203,7 @@ protected class KlientImpl(val endpoint: URI,
       .via(outgoingHttpConnection(endpoint, port, securedConnection))
       .runWith(Sink.head)
       .map(response => if(response.status.intValue() < 200 || response.status.intValue() > 299)
-            Some(response.entity.dataBytes.toString) else None)
+            Left(response.entity.dataBytes.toString) else Right(()))
     // TODO check entity handling
   }
 
@@ -217,7 +217,7 @@ protected class KlientImpl(val endpoint: URI,
    * @param event event to be posted
    * @return Option representing the error message or None in case of success
    */
-  override def postEventToPartition(topic: String, partitionId: String, event: Event): Future[Option[String]] = {
+  override def postEventToPartition(topic: String, partitionId: String, event: Event): Future[Either[String,Unit]] = {
     checkNotNull(topic, "topic must not be null")
     performEventPost(String.format(URI_EVENTS_ON_PARTITION, topic, partitionId), event)
   }

--- a/src/test/scala/org/zalando/nakadi/client/KlientSpec.scala
+++ b/src/test/scala/org/zalando/nakadi/client/KlientSpec.scala
@@ -210,8 +210,8 @@ class KlientSpec extends WordSpec with Matchers with BeforeAndAfterEach with Laz
       service.start()
 
       whenReady( klient.postEvent(topic, event), 10 seconds ) {
-        case Some(error) => fail(s"an error occurred while posting event to topic $topic")
-        case None => logger.debug("event post request was successful")
+        case Left(error) => fail(s"an error occurred while posting event to topic $topic")
+        case Right(_) => logger.debug("event post request was successful")
       }
 
       val request = performStandardRequestChecks(requestPath, requestMethod)


### PR DESCRIPTION
This does not change functionality. It just makes the prototypes of all the related methods similar. One can use Either[String,Unit] instead of Option[String].

The reason I would see this better is that Either is normally used for carrying a failure in its Left and success in its Right. Simply using that type conveys the intention to the (human) reader. Using Option[String] doesn't carry this meaning (in fact, it carries an opposite meaning, if anything).

Not a big thing.